### PR TITLE
Fixed bug with newer PHP strict type parameters checks

### DIFF
--- a/src/env-shim.php
+++ b/src/env-shim.php
@@ -44,23 +44,25 @@ namespace AAutoloadFirst\PHPExperts
             return value($default);
         }
 
-        switch (strtolower($value)) {
-            case 'true':
-            case '(true)':
-                return true;
-            case 'false':
-            case '(false)':
-                return false;
-            case 'empty':
-            case '(empty)':
-                return '';
-            case 'null':
-            case '(null)':
-                return;
-        }
+        if (is_string($value)) {
+            switch (strtolower($value)) {
+                case 'true':
+                case '(true)':
+                    return true;
+                case 'false':
+                case '(false)':
+                    return false;
+                case 'empty':
+                case '(empty)':
+                    return '';
+                case 'null':
+                case '(null)':
+                    return;
+            }
 
-        if (($valueLength = strlen($value)) > 1 && $value[0] === '"' && $value[$valueLength - 1] === '"') {
-            return substr($value, 1, -1);
+            if (($valueLength = strlen($value)) > 1 && $value[0] === '"' && $value[$valueLength - 1] === '"') {
+                return substr($value, 1, -1);
+            }
         }
 
         return $value;


### PR DESCRIPTION
It seems one small fix is needed for never PHP.  Some users notified me on ImpressCMS/impresscms#1158 about this issue. 

Now `strtolower` requires that parameter must be of string type, but in lib code that was not always the case. I'm not sure if my fix is best, but at least fixes such issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phpexpertsinc/laravel57-env-polyfill/3)
<!-- Reviewable:end -->
